### PR TITLE
Update zig-hashmaps-explained.md

### DIFF
--- a/content/2022/zig-hashmaps-explained.md
+++ b/content/2022/zig-hashmaps-explained.md
@@ -28,7 +28,7 @@ Or if you do not have string keys, you can use an `Auto` hashmap instead:
 var my_hash_map = std.AutoHashMap(K, V).init(allocator);
 ```
 
-Where `K` and `V` are your key and value data types, respectively. e.g. `[]const u8` for a string.
+Where `K` and `V` are your key and value data types, respectively. e.g. `u8` for a letter.
 
 You can then use these APIs:
 


### PR DESCRIPTION
Previously, it said you select AutoHashMap's data types, and gave a string as an example.  Directly above that it said "Or if you if you do not have string keys, you can use an `Auto` hashmap instead."  Further down below it also says strings can't be used with AutoHashMap.  Giving string as a data type might be a bit confusing (at least to me) considering the other statements.